### PR TITLE
321 workspace activity stream

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,8 @@ setup(name='ploneintranet.workspace',
           'plone.app.dexterity [grok]',
           'plone.namedfile [blobs]',
           'Products.CMFPlacefulWorkflow',
+          'plonesocial.microblog',
+          'plonesocial.activitystream',
           'ploneintranet.invitations',
       ],
       extras_require={

--- a/src/ploneintranet/workspace/profiles/default/metadata.xml
+++ b/src/ploneintranet/workspace/profiles/default/metadata.xml
@@ -4,5 +4,7 @@
   <dependencies>
   	<dependency>profile-collective.workspace:default</dependency>
     <dependency>profile-Products.CMFPlacefulWorkflow:base</dependency>
+    <dependency>profile-plonesocial.microblog:default</dependency>
+    <dependency>profile-plonesocial.activitystream:default</dependency>
   </dependencies>
 </metadata>

--- a/src/ploneintranet/workspace/profiles/default/types/ploneintranet.workspace.workspacefolder.xml
+++ b/src/ploneintranet/workspace/profiles/default/types/ploneintranet.workspace.workspacefolder.xml
@@ -22,6 +22,7 @@
      <element value="plone.app.content.interfaces.INameFromTitle" />
      <element value="plone.app.dexterity.behaviors.metadata.IBasic"/>
      <element value="collective.workspace.interfaces.IWorkspace"/>
+     <element value="plonesocial.microblog.interfaces.IMicroblogContext"/>
    </property>
 
   <!-- View information -->

--- a/src/ploneintranet/workspace/testing.py
+++ b/src/ploneintranet/workspace/testing.py
@@ -35,6 +35,20 @@ class PloneintranetworkspaceLayer(PloneSandboxLayer):
             context=configurationContext
         )
 
+        import plonesocial.microblog
+        xmlconfig.file(
+            'configure.zcml',
+            plonesocial.microblog,
+            context=configurationContext
+        )
+
+        import plonesocial.activitystream
+        xmlconfig.file(
+            'configure.zcml',
+            plonesocial.activitystream,
+            context=configurationContext
+        )
+
         import ploneintranet.invitations
         xmlconfig.file(
             'configure.zcml',


### PR DESCRIPTION
This pull request adds activity stream support onto the workspace.

This only concerns backend support, so in accord with what @gyst told me we only needed the content type to provide a specific interface, which is wat we do through a behavior.