### PR TITLE
Fix plone.protect issues

### DIFF
--- a/src/ploneintranet/workspace/utils.py
+++ b/src/ploneintranet/workspace/utils.py
@@ -133,9 +133,7 @@ def my_workspaces(context):
     return workspaces
 
 
-@memoize
 def existing_users(context):
-
     members = IWorkspace(context).members
     info = []
     for userid, details in members.items():

--- a/src/ploneintranet/workspace/utils.py
+++ b/src/ploneintranet/workspace/utils.py
@@ -134,6 +134,9 @@ def my_workspaces(context):
 
 
 def existing_users(context):
+    """
+    Look up the full user details for current workspace members
+    """
     members = IWorkspace(context).members
     info = []
     for userid, details in members.items():


### PR DESCRIPTION
* Disabled caching on the 'existing users' lookup, This was causing issues with plone.protect, as storing the cache on the workspace caused a 'write on read' when the members tab was loaded