### PR TITLE
Fix sidebar search injection setup

### DIFF
--- a/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
+++ b/src/ploneintranet/workspace/browser/tiles/templates/sidebar.pt
@@ -46,9 +46,14 @@
 
             <form class="search-box pat-inject pat-autosubmit" id="sidebar-search-form"
                   action="/feedback/workspace-search-results-min.html#items"
+                  data-pat-inject="source: #items; target: #items"
                   tal:attributes="action string:${context/absolute_url}/@@sidebar.default#workspace-documents">
                 <label>
-                    <input name="sidebar-search" type="search" placeholder="Search" />
+                    <input name="sidebar-search"
+			   type="search" 
+			   placeholder="Search" 
+			   tal:attributes="value 
+					   request/sidebar-search|nothing" />
                     <button type="submit">Search</button>
                 </label>
             </form>


### PR DESCRIPTION
Make sure only the search results are injected (previously this replaced the entire sidebar, including the search box, whenever the search was run - which stopped you from typing into it)